### PR TITLE
Fix typo in about section

### DIFF
--- a/news/index.html
+++ b/news/index.html
@@ -30,7 +30,7 @@
     <h1>News</h1>
     <table>
     
-        <tr valign="top"><td width="120px"><i>July 2024</i></td> <td>Our paper "Near-Optimal Performance of Stochastic Model Predictive Control" is accepted for publication in Mathematics of Operations Research
+        <tr valign="top"><td width="120px"><i>July 2025</i></td> <td>Our paper "Near-Optimal Performance of Stochastic Model Predictive Control" is accepted for publication in Mathematics of Operations Research
  [ <a href="https://arxiv.org/abs/2210.08599"> Link </a> ]<td></tr>
         
 


### PR DESCRIPTION
I suppose this is 2025:

> July 2024  Our paper "Near-Optimal Performance of Stochastic Model Predictive Control" is accepted for publication in Mathematics of Operations Research.